### PR TITLE
Escape markdown special characters in PR titles

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-save-prefix=''
 package-lock=false
+save-exact=false

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const { spawnSync } = require("child_process");
+const markdownEscape = require("markdown-escape");
 
 const generateChangelog = () => {
   const getOrigin = spawnSync("git", ["remote", "get-url", "origin"]);
@@ -79,7 +80,7 @@ const generateChangelog = () => {
       console.log(`### ${tag} (${date})\n`);
       merges.forEach(({ authors, mergeAuthor, message, pullRequestNumber }) => {
         console.log(
-          `- [#${pullRequestNumber}](${repositoryUrl}/pull/${pullRequestNumber}) ${message} (${authors.join(
+          `- [#${pullRequestNumber}](${repositoryUrl}/pull/${pullRequestNumber}) ${markdownEscape(message)} (${authors.join(
             ", "
           )})`
         );

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   },
   "bin": {
     "offline-github-changelog": "./bin/offline-github-changelog"
+  },
+  "dependencies": {
+    "markdown-escape": "^1.0.2"
   }
 }


### PR DESCRIPTION
Fixes some weird glitches in the Unexpected changelog where we often talk about things that can be interpreted as HTML tags, eg. `<object>`.

Before: https://github.com/unexpectedjs/unexpected/blob/bd08e6ed70e7873a5a9f432c51bf320d3bbedfc9/CHANGELOG.md

After: https://github.com/unexpectedjs/unexpected/blob/fa32778270dfaf3ffc1368e1963b357433a4a51c/CHANGELOG.md

Diff: https://github.com/unexpectedjs/unexpected/commit/fa32778270dfaf3ffc1368e1963b357433a4a51c