### PR TITLE
Also include regular commits (not via PRs) in the changelog to avoid gaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,31 +103,48 @@ const generateChangelog = (originName) => {
 
   for (const [i, { tag, date, merges, regularCommits }] of tags.entries()) {
     if (merges.length > 0 || regularCommits.length > 0) {
-      console.log(`### ${tag} (${date})\n`);
-      for (const { authors, mergeAuthor, message, pullRequestNumber } of merges) {
-        console.log(
-          `- [#${pullRequestNumber}](${repositoryUrl}/pull/${pullRequestNumber}) ${markdownEscape(message)} (${authors.join(
-            ", "
-          )})`
-        );
+      console.log(`### ${tag} (${date})`);
+      if (merges.length > 0) {
+        console.log(`\n#### Pull requests\n`);
+        for (const {
+          authors,
+          mergeAuthor,
+          message,
+          pullRequestNumber
+        } of merges) {
+          console.log(
+            `- [#${pullRequestNumber}](${repositoryUrl}/pull/${pullRequestNumber}) ${markdownEscape(
+              message
+            )} (${authors.join(", ")})`
+          );
+        }
       }
 
-      for (const { author, message, commitHash } of regularCommits.slice(0, MAX_REGULAR_COMMITS_PER_RELEASE)) {
-        console.log(
-          `- [${markdownEscape(message)}](${repositoryUrl}/commit/${commitHash}) (${author})`
-        );
-      }
-      if (regularCommits.length > MAX_REGULAR_COMMITS_PER_RELEASE) {
-        let compareFrom;
-        if (i === tags.length - 1) {
-          compareFrom = `${regularCommits[0].commitHash}^`;
-        } else {
-          compareFrom = tags[i + 1].tag;
+      if (regularCommits.length > 0) {
+        console.log(`\n#### Commits to master\n`);
+
+        for (const { author, message, commitHash } of regularCommits.slice(0, MAX_REGULAR_COMMITS_PER_RELEASE)) {
+          console.log(
+            `- [${markdownEscape(
+              message
+            )}](${repositoryUrl}/commit/${commitHash}) (${author})`
+          );
         }
-        const targetUrl = `${repositoryUrl}/compare/${encodeURIComponent(compareFrom)}...${encodeURIComponent(tag)}`;
-        console.log(
-          `- [+${regularCommits.length - MAX_REGULAR_COMMITS_PER_RELEASE} more](${targetUrl})`
-        );
+        if (regularCommits.length > MAX_REGULAR_COMMITS_PER_RELEASE) {
+          let compareFrom;
+          if (i === tags.length - 1) {
+            compareFrom = `${regularCommits[0].commitHash}^`;
+          } else {
+            compareFrom = tags[i + 1].tag;
+          }
+          const targetUrl = `${repositoryUrl}/compare/${encodeURIComponent(
+            compareFrom
+          )}...${encodeURIComponent(tag)}`;
+          console.log(
+            `- [+${regularCommits.length -
+              MAX_REGULAR_COMMITS_PER_RELEASE} more](${targetUrl})`
+          );
+        }
       }
 
       console.log();

--- a/index.js
+++ b/index.js
@@ -48,18 +48,17 @@ const generateChangelog = (originName) => {
           )[1];
           const [from, to] = parents.split(" ");
 
-          const authors = new Set();
           const getAuthors = spawnSync("git", [
             "log",
             "--pretty=[%an](mailto:%ae)",
             `${from}..${to}`
           ]);
 
-          getAuthors.stdout
+          const authors = new Set(getAuthors.stdout
             .toString()
             .split("\n")
             .filter(line => line)
-            .forEach(author => authors.add(author));
+          );
 
           return {
             authors: Array.from(authors).sort(),
@@ -102,22 +101,22 @@ const generateChangelog = (originName) => {
       };
     }).reverse();
 
-  tags.forEach(({ tag, date, merges, regularCommits }, i) => {
+  for (const [i, { tag, date, merges, regularCommits }] of tags.entries()) {
     if (merges.length > 0 || regularCommits.length > 0) {
       console.log(`### ${tag} (${date})\n`);
-      merges.forEach(({ authors, mergeAuthor, message, pullRequestNumber }) => {
+      for (const { authors, mergeAuthor, message, pullRequestNumber } of merges) {
         console.log(
           `- [#${pullRequestNumber}](${repositoryUrl}/pull/${pullRequestNumber}) ${markdownEscape(message)} (${authors.join(
             ", "
           )})`
         );
-      });
+      }
 
-      regularCommits.slice(0, MAX_REGULAR_COMMITS_PER_RELEASE).forEach(({ author, message, commitHash }) => {
+      for (const { author, message, commitHash } of regularCommits.slice(0, MAX_REGULAR_COMMITS_PER_RELEASE)) {
         console.log(
           `- [${markdownEscape(message)}](${repositoryUrl}/commit/${commitHash}) (${author})`
         );
-      });
+      }
       if (regularCommits.length > MAX_REGULAR_COMMITS_PER_RELEASE) {
         let compareFrom;
         if (i === tags.length - 1) {
@@ -133,7 +132,7 @@ const generateChangelog = (originName) => {
 
       console.log();
     }
-  });
+  }
 };
 
 module.exports = { generateChangelog };

--- a/index.js
+++ b/index.js
@@ -105,7 +105,10 @@ const generateChangelog = (originName) => {
     if (merges.length > 0 || regularCommits.length > 0) {
       console.log(`### ${tag} (${date})`);
       if (merges.length > 0) {
-        console.log(`\n#### Pull requests\n`);
+        if (regularCommits.length > 0) {
+          console.log(`\n#### Pull requests\n`);
+        }
+
         for (const {
           authors,
           mergeAuthor,
@@ -121,7 +124,9 @@ const generateChangelog = (originName) => {
       }
 
       if (regularCommits.length > 0) {
-        console.log(`\n#### Commits to master\n`);
+        if (merges.length > 0) {
+          console.log(`\n#### Commits to master\n`);
+        }
 
         for (const { author, message, commitHash } of regularCommits.slice(0, MAX_REGULAR_COMMITS_PER_RELEASE)) {
           console.log(

--- a/index.js
+++ b/index.js
@@ -103,10 +103,10 @@ const generateChangelog = (originName) => {
 
   for (const [i, { tag, date, merges, regularCommits }] of tags.entries()) {
     if (merges.length > 0 || regularCommits.length > 0) {
-      console.log(`### ${tag} (${date})`);
+      console.log(`### ${tag} (${date})\n`);
       if (merges.length > 0) {
         if (regularCommits.length > 0) {
-          console.log(`\n#### Pull requests\n`);
+          console.log(`#### Pull requests\n`);
         }
 
         for (const {
@@ -121,11 +121,12 @@ const generateChangelog = (originName) => {
             )} (${authors.join(", ")})`
           );
         }
+        console.log();
       }
 
       if (regularCommits.length > 0) {
         if (merges.length > 0) {
-          console.log(`\n#### Commits to master\n`);
+          console.log(`#### Commits to master\n`);
         }
 
         for (const { author, message, commitHash } of regularCommits.slice(0, MAX_REGULAR_COMMITS_PER_RELEASE)) {
@@ -150,9 +151,8 @@ const generateChangelog = (originName) => {
               MAX_REGULAR_COMMITS_PER_RELEASE} more](${targetUrl})`
           );
         }
+        console.log();
       }
-
-      console.log();
     }
   }
 };


### PR DESCRIPTION
Found out how to get the commits, but not yet how to avoid that they completely steal the show :)

Need to find a way to abbreviate them in the output. In its current form this change makes the assetgraph changelog go from 147252 bytes to 1199038 bytes, making [github refuse to render is as markdown](https://github.com/assetgraph/assetgraph/blob/master/CHANGELOG.md) :laughing: