### PR TITLE
Fix support for old tags/refs where %(ref) comes out empty for some reason

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const generateChangelog = (originName, next) => {
     'for-each-ref',
     '--sort=taggerdate',
     '--format',
-    '%(tag)|%(taggerdate:short)|%(objectname)',
+    '%(refname)|%(taggerdate:short)|%(objectname)',
     'refs/tags'
   ]);
 
@@ -23,9 +23,12 @@ const generateChangelog = (originName, next) => {
   const tagInfos = getTags.stdout
     .toString()
     .split('\n')
-    .filter(line => line && line.match(/^v?[0-9]+\.[0-9]+\.[0-9]+\|/))
+    .filter(
+      line => line && line.match(/^refs\/tags\/v?[0-9]+\.[0-9]+\.[0-9]+\|/)
+    )
     .map(line => {
-      const [tag, date, committish] = line.split('|');
+      const [ref, date, committish] = line.split('|');
+      const tag = ref.replace(/^refs\/tags\/v?/, 'v');
       return { tag, date, committish };
     });
 
@@ -122,7 +125,7 @@ const generateChangelog = (originName, next) => {
     { tag, date, merges, regularCommits }
   ] of releaseInfos.entries()) {
     if (merges.length > 0 || regularCommits.length > 0) {
-      console.log(`### ${tag} (${date})\n`);
+      console.log(`### ${tag}${date ? ` (${date})\n` : ''}`);
       if (merges.length > 0) {
         if (regularCommits.length > 0) {
           console.log(`#### Pull requests\n`);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const { spawnSync } = require('child_process');
 const markdownEscape = require('markdown-escape');
 const MAX_REGULAR_COMMITS_PER_RELEASE = 5;
+const semver = require('semver');
 
 const generateChangelog = (originName, next) => {
   const getOrigin = spawnSync('git', ['remote', 'get-url', originName]);
@@ -41,6 +42,9 @@ const generateChangelog = (originName, next) => {
   }
 
   const releaseInfos = tagInfos
+    .sort(({ tag: a }, { tag: b }) =>
+      semver.lt(a, b) ? -1 : semver.gt(a, b) ? 1 : 0
+    )
     .map(({ tag, date, committish }) => {
       const commitRange = lastCommittish
         ? `${lastCommittish}..${committish}`

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "prettier": "^1.16.4"
+    "prettier": "^1.16.4",
+    "semver": "^6.0.0"
   },
   "scripts": {
     "lint": "eslint . && prettier --check '**/*.js' 'bin/*'",


### PR DESCRIPTION
Both in unexpected and assetgraph I noticed that releases from before some time in 2013 weren't listed in the changelog. For some weird reason that I didn't explore further, the `git for-each-ref` format we use here receives empty strings for the `%(tag)` and `%(taggerdate:short)` fields, eg.:

```
||||081240541e4edbca44377538225b1fa16a396b50
```

Instead of the expected format, eg.:

```
v1.6.0|2013-11-28|1729ef1f851a7ecf7106d18094675a92e5235316
```

Seems like we can get a tag anyway by asking for `%(refname)` instead and stripping off `refs/tags/`.

Here's how it affects various changelogs:
* https://github.com/unexpectedjs/unexpected/commit/d090fd26c5f6cbbda643c0b0488e647c82632133
* https://github.com/assetgraph/assetgraph/commit/49c32ddc131c7f7f57a5efe88b340e40d101c773
* https://github.com/papandreou/node-cldr/commit/ca00d3eb71fe1641ad20e3f47d2ddf22860259d2