### PR TITLE
Replace LESS-THAN SIGN and GREATER-THAN SIGN with HTML entities

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,16 @@ const markdownEscape = require('markdown-escape');
 const MAX_REGULAR_COMMITS_PER_RELEASE = 5;
 const semver = require('semver');
 
+const htmlEntity = (c) =>
+  ({
+    '<': '&lt;',
+    '>': '&gt;',
+  }[c]);
+
+const htmlEscape = (s) => s.replace(/[<>]/, htmlEntity);
+
+const escapeText = (s) => htmlEscape(markdownEscape(s));
+
 const generateChangelog = (originName, next) => {
   const getOrigin = spawnSync('git', ['remote', 'get-url', originName]);
 
@@ -137,7 +147,7 @@ const generateChangelog = (originName, next) => {
 
         for (const { authors, message, pullRequestNumber } of merges) {
           console.log(
-            `- [#${pullRequestNumber}](${repositoryUrl}/pull/${pullRequestNumber}) ${markdownEscape(
+            `- [#${pullRequestNumber}](${repositoryUrl}/pull/${pullRequestNumber}) ${escapeText(
               message
             )} (${authors.join(', ')})`
           );


### PR DESCRIPTION
Fix an issue where commit messages containing HTML tags may result in
ambiguous markdown documents.

For instance a commit message with the text:

    <html dir="rtl">

Will result in a Markdown document containing that literal text.  This
renders correctly with GitHubs Markdown renderer but with e.g. pandoc
this results in an RTL html document with the following structure:

    <html>           -- from pandocs own template
    ...
    <html dir="rtl"> -- from the generated output
    ...
    </html>          -- from pandocs template

Which in turn may be interpreted as an RTL HTML document as is indeed
the case for Chrome Version 83.0.4103.116 (Official Build) (64-bit).

The caveat, of course, is that the Markdown document will now contain
more HTML entities than previously. Some of them may be unnecessary.

The tests were failing for me even before I made this change.