### PR TITLE
Add function to get a markdown changelog as a string

### DIFF
--- a/bin/offline-github-changelog
+++ b/bin/offline-github-changelog
@@ -33,11 +33,11 @@ const currentBranch = execSync('git rev-parse --abbrev-ref HEAD')
   .toString()
   .trim();
 
-const { generateChangelog } = require('../lib/index');
+const { printMarkdownChangelog } = require('../lib/index');
 const { remote, next } = cli.flags;
 
 try {
-  generateChangelog({
+  printMarkdownChangelog({
     originName: remote,
     nextVersion: next,
     currentBranch,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,11 @@
 const {
   extend,
   interleave,
+  join,
   parallel,
+  pipeline,
   program,
+  takeAll,
   tap,
 } = require('@transformation/core');
 
@@ -13,12 +16,8 @@ const repositoryUrl = require('./repositoryUrl');
 const tagToMarkdown = require('./tagToMarkdown');
 const addCommitSummary = require('./addCommitSummary');
 
-const generateChangelog = async ({
-  originName,
-  nextVersion,
-  currentBranch,
-}) => {
-  await program(
+const createChangelogPipeline = ({ originName, nextVersion, currentBranch }) =>
+  pipeline(
     tags({ nextVersion, currentBranch }),
     parallel(
       extend({
@@ -28,11 +27,34 @@ const generateChangelog = async ({
         regularCommits: regularCommits(),
       })
     ),
-    addCommitSummary(),
+    addCommitSummary()
+  );
+
+const markdownChangelogString = async ({
+  originName = 'origin',
+  currentBranch = 'master',
+  nextVersion,
+}) => {
+  const [markdown] = await takeAll(
+    createChangelogPipeline({ originName, nextVersion, currentBranch }),
+    tagToMarkdown({ currentBranch }),
+    join('\n\n')
+  );
+
+  return markdown;
+};
+
+const printMarkdownChangelog = async ({
+  originName = 'origin',
+  currentBranch = 'master',
+  nextVersion,
+}) => {
+  await program(
+    createChangelogPipeline({ originName, nextVersion, currentBranch }),
     tagToMarkdown({ currentBranch }),
     interleave(''),
     tap()
   );
 };
 
-module.exports = { generateChangelog };
+module.exports = { printMarkdownChangelog, markdownChangelogString };

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-const { generateChangelog } = require('../');
+const { printMarkdownChangelog, markdownChangelogString } = require('../');
 
 const { inspect } = require('util');
 const { resolve } = require('path');
@@ -34,7 +34,10 @@ describe('offline-github-changelog', () => {
   }
 
   it('should generate a changelog', async () => {
-    await generateChangelog({ originName: 'origin', currentBranch: 'master' });
+    await printMarkdownChangelog({
+      originName: 'origin',
+      currentBranch: 'master',
+    });
     expect(
       getOutput(),
       'to equal snapshot',
@@ -66,13 +69,63 @@ describe('offline-github-changelog', () => {
 
   describe('with the next switch', () => {
     it('should attribute the latest commits on master to the given version', async () => {
-      await generateChangelog({
+      await printMarkdownChangelog({
         originName: 'origin',
         nextVersion: '1.2.3',
         currentBranch: 'master',
       });
       expect(
         getOutput(),
+        'to equal snapshot',
+        expect.unindent`
+          ### v1.2.3 (2019-05-02)
+
+          #### Pull requests
+
+          - [#123](https://github.com/papandreou/offline-github-changelog-test1/pull/123) The title of some PR ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [#3](https://github.com/papandreou/offline-github-changelog-test1/pull/3) An unreleased feature ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          #### Commits to master
+
+          - [HTML in commit message: &lt;html dir="rtl"&gt;](https://github.com/papandreou/offline-github-changelog-test1/commit/af22733adbc2fc4977862348f68d152b754b4516) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [Unreleased commit on master](https://github.com/papandreou/offline-github-changelog-test1/commit/d3987d8212cb43ce39255877f75d45780c00b19a) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          ### v1.0.1
+
+          #### Pull requests
+
+          - [#2](https://github.com/papandreou/offline-github-changelog-test1/pull/2) Feature for one oh one ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          #### Commits to master
+
+          - [Release 1.0.1](https://github.com/papandreou/offline-github-changelog-test1/commit/825179ea6b03098ebba60e433be57dfdcef2a3bd) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [Another commit to master for 1.0.1](https://github.com/papandreou/offline-github-changelog-test1/commit/f9509628af0dc9753b4d7a69467e8f060fba85d0) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [Commit to master for 1.0.1](https://github.com/papandreou/offline-github-changelog-test1/commit/e110b7590329843a20a26ffbb7b971ec3bfd9fd4) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          ### v1.0.0
+
+          #### Pull requests
+
+          - [#1](https://github.com/papandreou/offline-github-changelog-test1/pull/1) Feature commit before first release ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          #### Commits to master
+
+          - [Release 1.0.0](https://github.com/papandreou/offline-github-changelog-test1/commit/e1fe60089ad08d31929707a1713d711e9a49b58c) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [Commit to master before first release](https://github.com/papandreou/offline-github-changelog-test1/commit/36851b522fc40ada3bb85d52d77183db23285143) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))`
+      );
+    });
+  });
+
+  describe('markdownChangelogString', () => {
+    it('returns the markdown changelog as a string', async () => {
+      const output = await markdownChangelogString({
+        originName: 'origin',
+        nextVersion: '1.2.3',
+        currentBranch: 'master',
+      });
+
+      expect(
+        output,
         'to equal snapshot',
         expect.unindent`
           ### v1.2.3 (2019-05-02)


### PR DESCRIPTION
Fixes: #40

```js
const output = await markdownChangelogString({
    originName: 'origin',
    nextVersion: '1.2.3',
    currentBranch: 'master',
  });
```