### PR TITLE
Add `--max-commits` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ offline-github-changelog > CHANGELOG.md
 
 # with a different remote
 offline-github-changelog --remote=myremote > CHANGELOG.md
+
+# with the max number of commits per release, omitting it defaults to 5
+offline-github-changelog --max-commits 3 > CHANGELOG.md
+
+# with 0 to not show the commits section, a negative value fallback to 0
+offline-github-changelog --max-commits 0 > CHANGELOG.md
 ```
 
 ### Releases

--- a/bin/offline-github-changelog
+++ b/bin/offline-github-changelog
@@ -7,11 +7,14 @@ const cli = require('meow')(
     $ offline-github-changelog
 
   Options
-    --remote, -r  Specify the remote
-    --next        Specify the version about to be released
+    --remote, -r      Specify the remote
+    --next            Specify the version about to be released
+    --max-commits, -c Specify the number of commits to show per release (default: 5)
 
   Examples
     $ offline-github-changelog > CHANGELOG.md
+    $ offline-github-changelog --max-commits 3 > CHANGELOG.md
+    $ offline-github-changelog --max-commits 0 > CHANGELOG.md // Pass 0 to not show the commits section
     $ offline-github-changelog --remote=myremote > CHANGELOG.md
     $ offline-github-changelog --next=1.2.4 > CHANGELOG.md
 `,
@@ -25,6 +28,11 @@ const cli = require('meow')(
       next: {
         type: 'string',
       },
+      maxCommits: {
+        type: 'number',
+        alias: 'c',
+        default: 5,
+      },
     },
   },
 );
@@ -34,12 +42,13 @@ const currentBranch = execSync('git rev-parse --abbrev-ref HEAD')
   .trim();
 
 const { printMarkdownChangelog } = require('../lib/index');
-const { remote, next } = cli.flags;
+const { remote, next, maxCommits } = cli.flags;
 
 try {
   printMarkdownChangelog({
     originName: remote,
     nextVersion: next,
+    numberCommits: maxCommits,
     currentBranch,
   }).catch((e) => {
     console.error(e);

--- a/lib/addCommitSummary.js
+++ b/lib/addCommitSummary.js
@@ -1,13 +1,14 @@
 const { extend } = require('@transformation/core');
 
-const MAX_REGULAR_COMMITS_PER_RELEASE = 5;
+const resolveNumberCommits = (numberCommits) =>
+  numberCommits < 0 ? 0 : numberCommits;
 
-const addCommitSummary = () =>
+const addCommitSummary = ({ numberCommits }) =>
   extend({
     commitSummary: ({ regularCommits }) =>
-      regularCommits.slice(0, MAX_REGULAR_COMMITS_PER_RELEASE),
+      regularCommits.slice(0, resolveNumberCommits(numberCommits)),
     moreCommits: ({ regularCommits }) =>
-      Math.max(regularCommits.length - MAX_REGULAR_COMMITS_PER_RELEASE, 0),
+      Math.max(regularCommits.length - resolveNumberCommits(numberCommits), 0),
   });
 
 module.exports = addCommitSummary;

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,12 @@ const repositoryUrl = require('./repositoryUrl');
 const tagToMarkdown = require('./tagToMarkdown');
 const addCommitSummary = require('./addCommitSummary');
 
-const createChangelogPipeline = ({ originName, nextVersion, currentBranch }) =>
+const createChangelogPipeline = ({
+  originName,
+  nextVersion,
+  currentBranch,
+  numberCommits,
+}) =>
   pipeline(
     tags({ nextVersion, currentBranch }),
     parallel(
@@ -27,16 +32,22 @@ const createChangelogPipeline = ({ originName, nextVersion, currentBranch }) =>
         regularCommits: regularCommits(),
       }),
     ),
-    addCommitSummary(),
+    addCommitSummary({ numberCommits }),
   );
 
 const markdownChangelogString = async ({
   originName = 'origin',
   currentBranch = 'master',
+  numberCommits = 5,
   nextVersion,
 }) => {
   const [markdown] = await takeAll(
-    createChangelogPipeline({ originName, nextVersion, currentBranch }),
+    createChangelogPipeline({
+      originName,
+      nextVersion,
+      currentBranch,
+      numberCommits,
+    }),
     tagToMarkdown({ currentBranch }),
     join('\n\n'),
   );
@@ -47,10 +58,16 @@ const markdownChangelogString = async ({
 const printMarkdownChangelog = async ({
   originName = 'origin',
   currentBranch = 'master',
+  numberCommits = 5,
   nextVersion,
 }) => {
   await program(
-    createChangelogPipeline({ originName, nextVersion, currentBranch }),
+    createChangelogPipeline({
+      originName,
+      nextVersion,
+      currentBranch,
+      numberCommits,
+    }),
     tagToMarkdown({ currentBranch }),
     interleave(''),
     tap(),

--- a/lib/templates/markdown.ejs
+++ b/lib/templates/markdown.ejs
@@ -9,8 +9,10 @@
 
 <%- include('pullRequests'); -%>
 
+<% if (commitSummary.length > 0) { -%>
 #### Commits to <%- this.currentBranch %>
 
 <%- include('commits'); -%>
+<% } -%>
 <% } -%>
 <% } -%>

--- a/test/index.js
+++ b/test/index.js
@@ -107,4 +107,205 @@ describe('offline-github-changelog', () => {
       );
     });
   });
+
+  describe('with the number of commits per release switch', () => {
+    it('should truncate to the number of commits specified', async () => {
+      const output = await markdownChangelogString({
+        originName: 'origin',
+        currentBranch: 'master',
+        numberCommits: 1,
+      });
+
+      expect(
+        output,
+        'to equal snapshot',
+        expect.unindent`
+          ### v1.0.1
+
+          #### Pull requests
+
+          - [#2](https://github.com/papandreou/offline-github-changelog-test1/pull/2) Feature for one oh one ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          #### Commits to master
+
+          - [Release 1.0.1](https://github.com/papandreou/offline-github-changelog-test1/commit/825179ea6b03098ebba60e433be57dfdcef2a3bd) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [+2 more](https://github.com/papandreou/offline-github-changelog-test1/compare/v1.0.0...v1.0.1)
+
+          ### v1.0.0
+
+          #### Pull requests
+
+          - [#1](https://github.com/papandreou/offline-github-changelog-test1/pull/1) Feature commit before first release ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          #### Commits to master
+
+          - [Release 1.0.0](https://github.com/papandreou/offline-github-changelog-test1/commit/e1fe60089ad08d31929707a1713d711e9a49b58c) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [+1 more](https://github.com/papandreou/offline-github-changelog-test1/compare/e1fe60089ad08d31929707a1713d711e9a49b58c...v1.0.0)`,
+      );
+    });
+
+    it('should fallback to 0 if a negative number of commits is provided', async () => {
+      const output = await markdownChangelogString({
+        originName: 'origin',
+        currentBranch: 'master',
+        numberCommits: -1,
+      });
+
+      expect(
+        output,
+        'to equal snapshot',
+        expect.unindent`
+          ### v1.0.1
+
+          #### Pull requests
+
+          - [#2](https://github.com/papandreou/offline-github-changelog-test1/pull/2) Feature for one oh one ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          ### v1.0.0
+
+          #### Pull requests
+
+          - [#1](https://github.com/papandreou/offline-github-changelog-test1/pull/1) Feature commit before first release ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))`,
+      );
+    });
+
+    it('should handle 0 as the number of regular commits to show', async () => {
+      const output = await markdownChangelogString({
+        originName: 'origin',
+        currentBranch: 'master',
+        numberCommits: 0,
+      });
+
+      expect(
+        output,
+        'to equal snapshot',
+        expect.unindent`
+          ### v1.0.1
+
+          #### Pull requests
+
+          - [#2](https://github.com/papandreou/offline-github-changelog-test1/pull/2) Feature for one oh one ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          ### v1.0.0
+
+          #### Pull requests
+
+          - [#1](https://github.com/papandreou/offline-github-changelog-test1/pull/1) Feature commit before first release ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))`,
+      );
+    });
+
+    it('should work with `nextVersion`', async () => {
+      const output = await markdownChangelogString({
+        originName: 'origin',
+        currentBranch: 'master',
+        nextVersion: '1.2.3',
+        numberCommits: 1,
+      });
+
+      expect(
+        output,
+        'to equal snapshot',
+        expect.unindent`
+          ### v1.2.3 (2019-05-02)
+
+          #### Pull requests
+
+          - [#123](https://github.com/papandreou/offline-github-changelog-test1/pull/123) The title of some PR ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [#3](https://github.com/papandreou/offline-github-changelog-test1/pull/3) An unreleased feature ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          #### Commits to master
+
+          - [HTML in commit message: &lt;html dir="rtl"&gt;](https://github.com/papandreou/offline-github-changelog-test1/commit/af22733adbc2fc4977862348f68d152b754b4516) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [+1 more](https://github.com/papandreou/offline-github-changelog-test1/compare/v1.0.1...v1.2.3)
+
+          ### v1.0.1
+
+          #### Pull requests
+
+          - [#2](https://github.com/papandreou/offline-github-changelog-test1/pull/2) Feature for one oh one ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          #### Commits to master
+
+          - [Release 1.0.1](https://github.com/papandreou/offline-github-changelog-test1/commit/825179ea6b03098ebba60e433be57dfdcef2a3bd) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [+2 more](https://github.com/papandreou/offline-github-changelog-test1/compare/v1.0.0...v1.0.1)
+
+          ### v1.0.0
+
+          #### Pull requests
+
+          - [#1](https://github.com/papandreou/offline-github-changelog-test1/pull/1) Feature commit before first release ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          #### Commits to master
+
+          - [Release 1.0.0](https://github.com/papandreou/offline-github-changelog-test1/commit/e1fe60089ad08d31929707a1713d711e9a49b58c) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [+1 more](https://github.com/papandreou/offline-github-changelog-test1/compare/e1fe60089ad08d31929707a1713d711e9a49b58c...v1.0.0)`,
+      );
+    });
+
+    it('should work with `nextVersion` and 0 commits', async () => {
+      const output = await markdownChangelogString({
+        originName: 'origin',
+        currentBranch: 'master',
+        nextVersion: '1.2.3',
+        numberCommits: 0,
+      });
+
+      expect(
+        output,
+        'to equal snapshot',
+        expect.unindent`
+          ### v1.2.3 (2019-05-02)
+
+          #### Pull requests
+
+          - [#123](https://github.com/papandreou/offline-github-changelog-test1/pull/123) The title of some PR ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [#3](https://github.com/papandreou/offline-github-changelog-test1/pull/3) An unreleased feature ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          ### v1.0.1
+
+          #### Pull requests
+
+          - [#2](https://github.com/papandreou/offline-github-changelog-test1/pull/2) Feature for one oh one ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          ### v1.0.0
+
+          #### Pull requests
+
+          - [#1](https://github.com/papandreou/offline-github-changelog-test1/pull/1) Feature commit before first release ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))`,
+      );
+    });
+
+    it('should work with `nextVersion` and negative number of commits', async () => {
+      const output = await markdownChangelogString({
+        originName: 'origin',
+        currentBranch: 'master',
+        nextVersion: '1.2.3',
+        numberCommits: -2,
+      });
+
+      expect(
+        output,
+        'to equal snapshot',
+        expect.unindent`
+          ### v1.2.3 (2019-05-02)
+
+          #### Pull requests
+
+          - [#123](https://github.com/papandreou/offline-github-changelog-test1/pull/123) The title of some PR ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+          - [#3](https://github.com/papandreou/offline-github-changelog-test1/pull/3) An unreleased feature ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          ### v1.0.1
+
+          #### Pull requests
+
+          - [#2](https://github.com/papandreou/offline-github-changelog-test1/pull/2) Feature for one oh one ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+          ### v1.0.0
+
+          #### Pull requests
+
+          - [#1](https://github.com/papandreou/offline-github-changelog-test1/pull/1) Feature commit before first release ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))`,
+      );
+    });
+  });
 });


### PR DESCRIPTION
This commit introduces the `--max-commits` flag.

This flag will allow to control the number of commits to display on each release:

- <0 : not allowed, fallback to 0
- 0 : no commits section will be shown
- \>0 : controls de amount of commits to show

Closes: https://github.com/sunesimonsen/offline-github-changelog/issues/101